### PR TITLE
Hide Ruby deprecation messages in Github Action Summary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         echo "This section will only list failures. For a more detailed report, see the 'rspec-results' artifact." >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY
-        bundle exec rspec --format failures --format html --out tmp/rspec-results.html -b --deprecation-out tmp/rspec-deprecations.txt >> $GITHUB_STEP_SUMMARY 2>&1
+        RUBYOPT="-W0" bundle exec rspec --format failures --format html --out tmp/rspec-results.html -b --deprecation-out tmp/rspec-deprecations.txt >> $GITHUB_STEP_SUMMARY 2>&1
         echo '```' >> $GITHUB_STEP_SUMMARY
     
     - name: Save test artifacts


### PR DESCRIPTION
## Description

Ruby 2.6 is a bit verbose as it turns out, & rspec is spitting out a deprecation message for each spec file to the GitHub Action Summary. To suppress these messages I've added a flag suppressing warning messages while running rspec in the main action.

Fixes # (issue)

## Type of change

Please select the relevant option.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## Checklist

Please review the following checklist and ensure all tasks are completed before submitting the pull request:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works