### PR TITLE
Adds `git` feature with version that adds support for SSH signing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,28 +14,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # [Optional] Uncomment this line to install additional gems.
 RUN gem install 'nokogiri:1.13.10' 'rails:4.2.11.3'
 
+# This section copies the mysql client configuration to the dev container so the user doesn't have to pass the mysql username & password each time
 COPY --chmod=664 ./.devcontainer/my.cnf /etc/mysql/my.cnf
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
-
-# [Optional] Docker
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends \
-#         ca-certificates \
-#         curl \
-#         gnupg \
-#         lsb-release
-
-# RUN mkdir -m 0755 -p /etc/apt/keyrings \
-#     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-
-# RUN echo \
-#     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-#     $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends \
-#     docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
-# RUN usermod -aG docker vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,10 @@
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
-  // "features": {},
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": { "version": "2.39.1" },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // This can be used to network with other containers or the host.
@@ -34,25 +37,10 @@
       "settings": {
         "sqltools.connections": [
           {
-            "name": "Development Database",
+            "name": "Application Database",
             "driver": "MySQL",
             "previewLimit": 50,
             "server": "db",
-            "database": "app_development",
-            "port": 3306,
-            "username": "vscode",
-            "password": "vscode",
-            "askForPassword": false,
-            "mysqlOptions": {
-              "authProtocol": "default"
-            }
-          },
-          {
-            "name": "Test Database",
-            "driver": "MySQL",
-            "previewLimit": 50,
-            "server": "db",
-            "database": "app_test",
             "port": 3306,
             "username": "vscode",
             "password": "vscode",


### PR DESCRIPTION
## Description

This issues relates to #4 where I was able to get local dev containers to start but alas I ran into some issues. One of the issues was that git wasn't working. Turns out local dev containers copy over your git config & in my git config I had SSH signing configured, which as it turns out Debian bullseye doesn't package a version of git which supports SSH signing.

I've updated the `devcontainer.json` file, adding two features, one of which is the latest version of git and the other being the `gh` CLI, which might come in handy.

We could go further and add features like the AWS CLI, & Docker-in-Docker, but for the moment this is overkill until we decide that it's worth teaching this early on.

Lastly, local dev containers won't work for the moment due to a breaking change in Visual Studio Code v1.75. To get local dev containers working you will need to revert to 1.74.3 until 1.76 is released in March. There is also the insiders version of VS Code which includes the fix if you'd prefer to do that.

Fixes # (issue)

## Type of change

Please select the relevant option.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## Checklist

Please review the following checklist and ensure all tasks are completed before submitting the pull request:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works