### PR TITLE
`postCreateCommand` waits up to 30 seconds for MySQL server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
   // This command is the last of three that finalizes container setup when a dev container is 
   // created. It happens after updateContentCommand and once the dev container has been assigned
   // to a user for the first time.
-  "postCreateCommand": "bundle install && bundle e rake db:setup",
+  "postCreateCommand": "bundle install && wait-for-it db:3306 -t 30 && bundle e rake db:setup || echo \"MySQL server is unresponsive.\n\"",
 
   // Use 'postStartCommand' to run commands after the container is started.
   // "postStartCommand": "",


### PR DESCRIPTION
## Description

After rebuilding the container my environment failed because the host `db` wasn't reachable, I'm assuming that the service was still starting so I've wrapped the `rake db:setup` command in a `wait-for-it` guard clause that'll only run the database setup if MySQL has started.

Fixes # (issue)

## Type of change

Please select the relevant option.

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Other

## Checklist

Please review the following checklist and ensure all tasks are completed before submitting the pull request:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works