### PR TITLE
Cleanup Cache on Pull Request Close

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,33 @@
+name: Cleanup Cache on PR Close
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -32,9 +32,7 @@ jobs:
         bundler-cache: true
 
     - name: Index Bundler Gems
-      run: |
-        bundle --full-index
-        bundle exec gem pristine mysql2
+      run: bundle install --jobs 4 --retry 3
     
     - name: Wait for Service
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -31,8 +31,8 @@ jobs:
       with:
         bundler-cache: true
 
-    - name: Pristine mysql2
-      run: bundle exec gem pristine mysql2
+    - name: Index Bundler Gems
+      run: bundle --full-index
     
     - name: Wait for Service
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -38,7 +38,7 @@ jobs:
         ./wait-for-it.sh 127.0.0.1:3306 --timeout=30 --strict --quiet
 
     - name: Setup Database
-      run: bundle exec rake db:setup
+      run: RUBYOPT="-W0" bundle exec rake db:setup
 
     - name: Run RSpec
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -32,7 +32,9 @@ jobs:
         bundler-cache: true
 
     - name: Index Bundler Gems
-      run: bundle --full-index
+      run: |
+        bundle --full-index
+        bundle exec gem pristine mysql2
     
     - name: Wait for Service
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -30,6 +30,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+
+    - name: Pristine mysql2
+      run: bundle exec gem pristine mysql2
     
     - name: Wait for Service
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: false
+        bundler-cache: true
 
     - name: Install Dependencies
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -5,7 +5,7 @@ env:
   RAILS_ENV: test
   RACK_ENV: test
   COVERAGE: true
-  DATABASE_HOST: 127.0.0.1
+  DATABASE_HOST: mysql
   DATABASE_USERNAME: root
   DATABASE_PASSWORD: password
 
@@ -35,7 +35,7 @@ jobs:
       run: |
         wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
         chmod +x wait-for-it.sh
-        ./wait-for-it.sh 127.0.0.1:3306 --timeout=30 --strict --quiet
+        ./wait-for-it.sh mysql:3306 --timeout=30 --strict --quiet
 
     - name: Setup Database
       run: RUBYOPT="-W0" bundle exec rake db:setup

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -30,11 +30,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-
-    - name: Install Dependencies
-      run: |
-        gem install bundler -v 1.17.3
-        bundle install --jobs 4 --retry 3
     
     - name: Wait for Service
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -5,7 +5,7 @@ env:
   RAILS_ENV: test
   RACK_ENV: test
   COVERAGE: true
-  DATABASE_HOST: mysql
+  DATABASE_HOST: localhost
   DATABASE_USERNAME: root
   DATABASE_PASSWORD: password
 
@@ -35,7 +35,7 @@ jobs:
       run: |
         wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
         chmod +x wait-for-it.sh
-        ./wait-for-it.sh mysql:3306 --timeout=30 --strict --quiet
+        ./wait-for-it.sh localhost:3306 --timeout=30 --strict --quiet
 
     - name: Setup Database
       run: RUBYOPT="-W0" bundle exec rake db:setup

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -5,7 +5,7 @@ env:
   RAILS_ENV: test
   RACK_ENV: test
   COVERAGE: true
-  DATABASE_HOST: localhost
+  DATABASE_HOST: 127.0.0.1
   DATABASE_USERNAME: root
   DATABASE_PASSWORD: password
 
@@ -29,13 +29,13 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true
+        bundler-cache: false
     
     - name: Wait for Service
       run: |
         wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
         chmod +x wait-for-it.sh
-        ./wait-for-it.sh localhost:3306 --timeout=30 --strict --quiet
+        ./wait-for-it.sh 127.0.0.1:3306 --timeout=30 --strict --quiet
 
     - name: Setup Database
       run: RUBYOPT="-W0" bundle exec rake db:setup

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -30,6 +30,11 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: false
+
+    - name: Install Dependencies
+      run: |
+        gem install bundler -v 1.17.3
+        bundle install --jobs 4 --retry 3
     
     - name: Wait for Service
       run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -31,7 +31,8 @@ jobs:
       with:
         bundler-cache: true
 
-    - name: Index Bundler Gems
+    # For some reason, gems with native extensions fail to install without this step
+    - name: Install Dependencies
       run: bundle install --jobs 4 --retry 3
     
     - name: Wait for Service


### PR DESCRIPTION
## Description

Adds a GitHub workflow that removes any cache for a PR that's been closed.

Additionally, it appears the cache causes problems when gems with native extensions are present. Currently, the best workaround I have found is to run `bundle install` again. This is still fast.

Fixes # (issue)

## Type of change

Please select the relevant option.

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Other

## Checklist

Please review the following checklist and ensure all tasks are completed before submitting the pull request:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works